### PR TITLE
feat(profileSettings): add API logic for profile setting post

### DIFF
--- a/TwoHoSun.xcodeproj/project.pbxproj
+++ b/TwoHoSun.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		FD9280392ADD8A0E007285BA /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9280382ADD8A0E007285BA /* LoginModel.swift */; };
 		FD92803D2ADD8AF0007285BA /* File in Resources */ = {isa = PBXBuildFile; fileRef = FD92803C2ADD8AF0007285BA /* File */; };
 		FDDB990C2ADC1BEC00B1163F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = FDDB990B2ADC1BEC00B1163F /* .swiftlint.yml */; };
+		FDE9FC9B2ADF28CF00EBC1F8 /* ProfileSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE9FC9A2ADF28CF00EBC1F8 /* ProfileSettingModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +60,7 @@
 		FD92803C2ADD8AF0007285BA /* File */ = {isa = PBXFileReference; lastKnownFileType = text; path = File; sourceTree = "<group>"; };
 		FDDB99042ADBF37100B1163F /* TwoHoSun.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TwoHoSun.entitlements; sourceTree = "<group>"; };
 		FDDB990B2ADC1BEC00B1163F /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		FDE9FC9A2ADF28CF00EBC1F8 /* ProfileSettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +153,7 @@
 			children = (
 				FD9280382ADD8A0E007285BA /* LoginModel.swift */,
 				FD4E75B32ADE9616000C2277 /* NicknameModel.swift */,
+				FDE9FC9A2ADF28CF00EBC1F8 /* ProfileSettingModel.swift */,
 				C7E459CC2ADE8A1300ECD008 /* GeneralResponse.swift */,
 				AB4522552ADDDBC400B69F24 /* SchoolResponseModel.swift */,
 				AB4522572ADDDBE000B69F24 /* SchoolModel.swift */,
@@ -316,9 +319,9 @@
 				C7F1FD842ADDA2F000C5A2A1 /* OnBoardingView.swift in Sources */,
 				AB4522532ADDD99500B69F24 /* SchoolSearchView.swift in Sources */,
 				C7E30E2B2ADC40E4001AE89B /* LoginViewModel.swift in Sources */,
+				FDE9FC9B2ADF28CF00EBC1F8 /* ProfileSettingModel.swift in Sources */,
 				FD9280392ADD8A0E007285BA /* LoginModel.swift in Sources */,
 				C7E459CD2ADE8A1300ECD008 /* GeneralResponse.swift in Sources */,
-				FD132BF02ADBE8FA00F31AAF /* ContentView.swift in Sources */,
 				FD8D9F812ADC5FAD0072F4BA /* KeychainManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TwoHoSun/Model/GeneralResponse.swift
+++ b/TwoHoSun/Model/GeneralResponse.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 struct GeneralResponse<T: Decodable>: Decodable {
     var status: Int
     var message: String
@@ -24,3 +25,5 @@ struct GeneralResponse<T: Decodable>: Decodable {
         data = (try? values.decode(T.self, forKey: .data)) ?? nil
     }
 }
+
+struct NoData: Decodable {}

--- a/TwoHoSun/Model/ProfileSettingModel.swift
+++ b/TwoHoSun/Model/ProfileSettingModel.swift
@@ -1,0 +1,15 @@
+//
+//  ProfileSettingModel.swift
+//  TwoHoSun
+//
+//  Created by 관식 on 10/18/23.
+//
+
+import Foundation
+
+struct ProfileSetting: Codable {
+    var userProfileImage: String
+    var userNickname: String
+    var school: SchoolModel
+    var grade: Int
+}

--- a/TwoHoSun/Model/SchoolModel.swift
+++ b/TwoHoSun/Model/SchoolModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct SchoolModel {
+struct SchoolModel: Codable {
     let schoolName: String
     let schoolRegion: String
     let schoolType: String

--- a/TwoHoSun/Screens/ProfileSettings/ProfileSettingViewModel.swift
+++ b/TwoHoSun/Screens/ProfileSettings/ProfileSettingViewModel.swift
@@ -20,7 +20,7 @@ class ProfileSettingViewModel {
         let requestURL = URLConst.baseURL + "/api/profiles/isValidNickname"
         let headers: HTTPHeaders = [
             "Content-Type": "application/json",
-            "Authorization": "Bearer \(KeychainManager.shared.readToken(key: "accessToken"))"
+            "Authorization": "Bearer \(KeychainManager.shared.readToken(key: "accessToken")!)"
         ]
         let body: [String: String] = ["userNickname": nickname]
         
@@ -37,10 +37,44 @@ class ProfileSettingViewModel {
                     print("Error: \(error)")
                 }
             } receiveValue: { data in
-                self.isDuplicated = data.isExist
-                print("Nickname is duplicated: \(data.isExist)")
+                self.isDuplicated = data!.isExist
+                print("Nickname is duplicated: \(data!.isExist)")
+            }
+            .store(in: &cancellable)
+    }
+    
+    func postProfileSetting(userProfileImage: String, userNickname: String, school: SchoolModel, grade: Int) {
+        let requestURL = URLConst.baseURL + "/api/profiles"
+        let headers: HTTPHeaders = [
+            "Content-Type": "application/json",
+            "Authorization": "Bearer \(KeychainManager.shared.readToken(key: "accessToken")!)"
+        ]
+        let body: [String: Any] = [
+            "userProfileImage": userProfileImage,
+            "userNickname": userNickname,
+            "school": [
+                "schoolName": school.schoolName,
+                "schoolRegion": school.schoolRegion,
+                "schoolType": school.schoolType
+            ],
+            "grade": grade
+        ]
+        
+        AF.request(requestURL, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers)
+            .publishDecodable(type: GeneralResponse<NoData>.self)
+            .value()
+            .map(\.message)
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    print("Error: \(error)")
+                }
+            } receiveValue: { message in
+                print("The result of posting profile: \(message)")
             }
             .store(in: &cancellable)
     }
 }
-


### PR DESCRIPTION
## 🔥 Pull requests

🍃 작업한 브랜치
- feature/#19

## ✏️ 작업한 내용 
설정한 프로필에 대해 서버에 등록하기 위한 API 통신
- [x] 프로필 모델 작성
- [x] API 통신 로직 구현

## 📌 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📷 스크린샷
<!-- 작업한 뷰의 스크린샷을 올려주세요. -->
<!-- 이미지 크기를 30%로 줄여서 올려주세요. ex. <img src = "이미지 주소" width = 30%>-->

## 📮 관련 이슈
- Resolved: #19 
