### PR TITLE
알림뷰 레이아웃 제작

### DIFF
--- a/TwoHoSun.xcodeproj/project.pbxproj
+++ b/TwoHoSun.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		ABB71D742AE2758200BE0671 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D732AE2758200BE0671 /* ImageDetailView.swift */; };
 		ABB71D762AE2758B00BE0671 /* VoteCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D752AE2758B00BE0671 /* VoteCellView.swift */; };
 		ABB71D7A2AE2A64300BE0671 /* LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D792AE2A64300BE0671 /* LinkView.swift */; };
+		ABB71D7C2AE2B3F100BE0671 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D7B2AE2B3F100BE0671 /* NotificationView.swift */; };
 		C7DE44BB2AE0BBD9001639CB /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DE44BA2AE0BBD9001639CB /* DetailView.swift */; };
 		C7DE44BD2AE0DCE7001639CB /* CommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DE44BC2AE0DCE7001639CB /* CommentCell.swift */; };
 		C7DE44C22AE26109001639CB /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DE44C12AE26109001639CB /* View+.swift */; };
@@ -60,6 +61,7 @@
 		ABB71D732AE2758200BE0671 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
 		ABB71D752AE2758B00BE0671 /* VoteCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteCellView.swift; sourceTree = "<group>"; };
 		ABB71D792AE2A64300BE0671 /* LinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkView.swift; sourceTree = "<group>"; };
+		ABB71D7B2AE2B3F100BE0671 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 		C7DE44BA2AE0BBD9001639CB /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		C7DE44BC2AE0DCE7001639CB /* CommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCell.swift; sourceTree = "<group>"; };
 		C7DE44C12AE26109001639CB /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 			children = (
 				FD3205602ADD1F8100B0D5F6 /* MainView.swift */,
 				C7E459D22AE01FDE00ECD008 /* MainViewModel.swift */,
+				ABB71D7B2AE2B3F100BE0671 /* NotificationView.swift */,
 			);
 			path = MainView;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 				FD3205682ADD5C0D00B0D5F6 /* TwoHoSunApp.swift in Sources */,
 				C7F1FD842ADDA2F000C5A2A1 /* OnBoardingView.swift in Sources */,
 				C7DE44BD2AE0DCE7001639CB /* CommentCell.swift in Sources */,
+				ABB71D7C2AE2B3F100BE0671 /* NotificationView.swift in Sources */,
 				C7E459D62AE03FEF00ECD008 /* WriteView.swift in Sources */,
 				AB4522532ADDD99500B69F24 /* SchoolSearchView.swift in Sources */,
 				C7E459D32AE01FDE00ECD008 /* MainViewModel.swift in Sources */,

--- a/TwoHoSun.xcodeproj/project.pbxproj
+++ b/TwoHoSun.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		ABB71D722AE2756E00BE0671 /* VoteContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D712AE2756E00BE0671 /* VoteContentView.swift */; };
 		ABB71D742AE2758200BE0671 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D732AE2758200BE0671 /* ImageDetailView.swift */; };
 		ABB71D762AE2758B00BE0671 /* VoteCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D752AE2758B00BE0671 /* VoteCellView.swift */; };
+		ABB71D7A2AE2A64300BE0671 /* LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB71D792AE2A64300BE0671 /* LinkView.swift */; };
 		C7DE44BB2AE0BBD9001639CB /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DE44BA2AE0BBD9001639CB /* DetailView.swift */; };
 		C7DE44BD2AE0DCE7001639CB /* CommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DE44BC2AE0DCE7001639CB /* CommentCell.swift */; };
 		C7DE44C22AE26109001639CB /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DE44C12AE26109001639CB /* View+.swift */; };
@@ -58,6 +59,7 @@
 		ABB71D712AE2756E00BE0671 /* VoteContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteContentView.swift; sourceTree = "<group>"; };
 		ABB71D732AE2758200BE0671 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
 		ABB71D752AE2758B00BE0671 /* VoteCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteCellView.swift; sourceTree = "<group>"; };
+		ABB71D792AE2A64300BE0671 /* LinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkView.swift; sourceTree = "<group>"; };
 		C7DE44BA2AE0BBD9001639CB /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		C7DE44BC2AE0DCE7001639CB /* CommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCell.swift; sourceTree = "<group>"; };
 		C7DE44C12AE26109001639CB /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 				ABB71D712AE2756E00BE0671 /* VoteContentView.swift */,
 				ABB71D732AE2758200BE0671 /* ImageDetailView.swift */,
 				ABB71D752AE2758B00BE0671 /* VoteCellView.swift */,
+				ABB71D792AE2A64300BE0671 /* LinkView.swift */,
 			);
 			path = Vote;
 			sourceTree = "<group>";
@@ -388,6 +391,7 @@
 				AB4D82692ADD7F4D00F35CCB /* ProfileSettingsView.swift in Sources */,
 				ABB71D722AE2756E00BE0671 /* VoteContentView.swift in Sources */,
 				ABB71D6E2AE2754300BE0671 /* PostResponseModel.swift in Sources */,
+				ABB71D7A2AE2A64300BE0671 /* LinkView.swift in Sources */,
 				FD4E75B62ADE9C20000C2277 /* ProfileSettingViewModel.swift in Sources */,
 				AB45225C2ADE665100B69F24 /* URLConst.swift in Sources */,
 				C7DE44BB2AE0BBD9001639CB /* DetailView.swift in Sources */,

--- a/TwoHoSun/Screens/Home/MainTabView.swift
+++ b/TwoHoSun/Screens/Home/MainTabView.swift
@@ -11,7 +11,7 @@ struct MainTabView : View {
     @State private var selection = 0
     var body: some View {
             TabView(selection: $selection) {
-                MainView()
+                    MainView()
                     .tabItem {
                         iconImage("1.square.fill")
                     }

--- a/TwoHoSun/Screens/Home/MainView/MainView.swift
+++ b/TwoHoSun/Screens/Home/MainView/MainView.swift
@@ -67,11 +67,13 @@ struct MainView: View {
 
 extension MainView {
     private var noticeButton: some View {
-        Button(action: {
-            // TODO: 알림페이지로 넘어가도록
-        }, label: {
+        NavigationLink {
+            NotificationView()
+        } label: {
             Image(systemName: "bell.fill")
-        })
+                .font(.system(size: 16))
+                .foregroundStyle(.gray)
+        }
     }
 
     private var searchButton: some View {

--- a/TwoHoSun/Screens/Home/MainView/NotificationView.swift
+++ b/TwoHoSun/Screens/Home/MainView/NotificationView.swift
@@ -58,6 +58,7 @@ extension NotificationView {
         }
         .listStyle(.plain)
         .listSectionSpacing(0)
+        .scrollIndicators(.hidden)
     }
 
     private func listHeader(_ headerName: String) -> some View {
@@ -78,7 +79,7 @@ extension NotificationView {
                 .frame(width: 46, height: 46)
                 .foregroundStyle(.gray)
             VStack(alignment: .leading, spacing: 6) {
-                Text("OO님이 회원님의 게시글에 답글을 남겼어요.")
+                Text("밍니님이 회원님의 게시글에 답글을\n남겼어요.")
                     .font(.system(size: 16, weight: .medium))
                 Text("2분 전")
                     .font(.system(size: 14))
@@ -96,7 +97,7 @@ extension NotificationView {
                 .foregroundStyle(.gray)
                 .padding(.trailing, 14)
             VStack(alignment: .leading) {
-                Text("OO님이 회원님의 게시글에 답글을\n남겼어요.")
+                Text("바부님이 회원님의 게시글에 답글을\n남겼어요.")
                     .font(.system(size: 16, weight: .medium))
                 Spacer()
                 Text("2분 전")

--- a/TwoHoSun/Screens/Home/MainView/NotificationView.swift
+++ b/TwoHoSun/Screens/Home/MainView/NotificationView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct NotificationView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
-
+    @State private var dismiss: Bool = false
     var body: some View {
         ZStack {
             Color.white
@@ -24,6 +24,8 @@ struct NotificationView: View {
             }
         }
         .toolbarBackground(.white, for: .navigationBar)
+        .toolbar(dismiss ? .visible : .hidden, for: .tabBar)
+
     }
 }
 
@@ -31,6 +33,7 @@ extension NotificationView {
 
     private var backButton: some View {
         Button {
+            dismiss.toggle()
             self.presentationMode.wrappedValue.dismiss()
         } label: {
             Image(systemName: "chevron.backward")

--- a/TwoHoSun/Screens/Home/MainView/NotificationView.swift
+++ b/TwoHoSun/Screens/Home/MainView/NotificationView.swift
@@ -13,8 +13,8 @@ struct NotificationView: View {
     var body: some View {
         ZStack {
             Color.white
+            notificationList
         }
-        .ignoresSafeArea()
         .navigationBarBackButtonHidden()
         .navigationTitle("알림")
         .navigationBarTitleDisplayMode(.inline)
@@ -23,7 +23,7 @@ struct NotificationView: View {
                 backButton
             }
         }
-        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarBackground(.white, for: .navigationBar)
     }
 }
 
@@ -38,10 +38,83 @@ extension NotificationView {
                 .foregroundStyle(.gray)
         }
     }
+
+    private var notificationList: some View {
+        List {
+            listHeader("오늘 알림")
+                .listRowSeparator(.hidden)
+            ForEach(0..<3) { _ in
+                notificationCell
+            }
+            .listRowInsets(EdgeInsets())
+            .listRowSeparator(.hidden)
+            listHeader("이전 알림")
+                .listRowSeparator(.hidden)
+            ForEach(0..<10) { _ in
+                notificationCellWithPostIcon
+            }
+            .listRowInsets(EdgeInsets())
+            .listRowSeparator(.hidden)
+        }
+        .listStyle(.plain)
+        .listSectionSpacing(0)
+    }
+
+    private func listHeader(_ headerName: String) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Rectangle()
+                .frame(height: 1)
+            Text(headerName)
+                .font(.system(size: 14, weight: .medium))
+                .padding(.leading, 15)
+                .padding(.bottom, 10)
+        }
+        .foregroundStyle(.gray)
+    }
+
+    private var notificationCell: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Circle()
+                .frame(width: 46, height: 46)
+                .foregroundStyle(.gray)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("OO님이 회원님의 게시글에 답글을 남겼어요.")
+                    .font(.system(size: 16, weight: .medium))
+                Text("2분 전")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.gray)
+            }
+        }
+        .padding(.horizontal, 26)
+        .padding(.vertical, 15)
+    }
+
+    private var notificationCellWithPostIcon: some View {
+        HStack(alignment: .top, spacing: 0) {
+            Circle()
+                .frame(width: 46, height: 46)
+                .foregroundStyle(.gray)
+                .padding(.trailing, 14)
+            VStack(alignment: .leading) {
+                Text("OO님이 회원님의 게시글에 답글을\n남겼어요.")
+                    .font(.system(size: 16, weight: .medium))
+                Spacer()
+                Text("2분 전")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.gray)
+            }
+            Spacer()
+            RoundedRectangle(cornerRadius: 8)
+                .frame(width: 40, height: 40)
+                .foregroundStyle(.gray)
+        }
+        .padding(.horizontal, 26)
+        .padding(.vertical, 15)
+    }
 }
 
 #Preview {
-    NavigationStack {
+    NavigationView {
         NotificationView()
     }
 }

--- a/TwoHoSun/Screens/Home/MainView/NotificationView.swift
+++ b/TwoHoSun/Screens/Home/MainView/NotificationView.swift
@@ -1,0 +1,46 @@
+//
+//  NotificationView.swift
+//  TwoHoSun
+//
+//  Created by 김민 on 10/20/23.
+//
+
+import SwiftUI
+
+struct NotificationView: View {
+
+    var body: some View {
+        ZStack{
+            Color.white
+        }
+        .ignoresSafeArea()
+        .navigationBarBackButtonHidden()
+        .navigationTitle("알림")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                backButton
+            }
+        }
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+}
+
+extension NotificationView {
+
+    private var backButton: some View {
+        Button {
+
+        } label: {
+            Image(systemName: "chevron.backward")
+                .font(.system(size: 20))
+                .foregroundStyle(.gray)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        NotificationView()
+    }
+}

--- a/TwoHoSun/Screens/Home/MainView/NotificationView.swift
+++ b/TwoHoSun/Screens/Home/MainView/NotificationView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct NotificationView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
     var body: some View {
-        ZStack{
+        ZStack {
             Color.white
         }
         .ignoresSafeArea()
@@ -30,7 +31,7 @@ extension NotificationView {
 
     private var backButton: some View {
         Button {
-
+            self.presentationMode.wrappedValue.dismiss()
         } label: {
             Image(systemName: "chevron.backward")
                 .font(.system(size: 20))

--- a/TwoHoSun/Screens/Home/Vote/ImageDetailView.swift
+++ b/TwoHoSun/Screens/Home/Vote/ImageDetailView.swift
@@ -11,7 +11,9 @@ import Kingfisher
 
 struct ImageDetailView: View {
     @Environment(\.dismiss) var dismiss
-    @Binding var image: String
+    @State private var isLinkWebViewPresented = false
+    var imageURL: String
+    var externalURL: String
 
     var body: some View {
         ZStack {
@@ -35,6 +37,11 @@ struct ImageDetailView: View {
                     .foregroundStyle(.white)
             }
         }
+        .fullScreenCover(isPresented: $isLinkWebViewPresented) {
+            NavigationView {
+                LinkView(externalURL: externalURL)
+            }
+        }
     }
 }
 
@@ -51,7 +58,7 @@ extension ImageDetailView {
     }
 
     private var imageView: some View {
-        KFImage(URL(string: image)!)
+        KFImage(URL(string: imageURL)!)
             .placeholder {
                 ProgressView()
             }
@@ -65,7 +72,7 @@ extension ImageDetailView {
 
     private var detailLinkButton: some View {
         Button {
-            print("linkButton did tap")
+            isLinkWebViewPresented = true
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: "link")
@@ -83,6 +90,7 @@ extension ImageDetailView {
 
 #Preview {
     NavigationView {
-        ImageDetailView(image: .constant("https://picsum.photos/200/300"))
+        ImageDetailView(imageURL: "https://picsum.photos/200/300",
+                        externalURL: "https://youtu.be/SfqR33YnEAE?si=5QLZhFhwGKZb2hZB")
     }
 }

--- a/TwoHoSun/Screens/Home/Vote/LinkView.swift
+++ b/TwoHoSun/Screens/Home/Vote/LinkView.swift
@@ -13,9 +13,7 @@ struct LinkView: View {
     var externalURL: String
 
     var body: some View {
-        ZStack {
-            LinkWebView(externalURL: externalURL)
-        }
+        LinkWebView(externalURL: externalURL)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 dismissButton

--- a/TwoHoSun/Screens/Home/Vote/LinkView.swift
+++ b/TwoHoSun/Screens/Home/Vote/LinkView.swift
@@ -1,0 +1,62 @@
+//
+//  LinkView.swift
+//  TwoHoSun
+//
+//  Created by 김민 on 10/20/23.
+//
+
+import SwiftUI
+import WebKit
+
+struct LinkView: View {
+    @Environment(\.dismiss) var dismiss
+    var externalURL: String
+
+    var body: some View {
+        ZStack {
+            LinkWebView(externalURL: externalURL)
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                dismissButton
+            }
+        }
+    }
+}
+
+extension LinkView {
+
+    private var dismissButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 20))
+                .foregroundStyle(.black)
+        }
+    }
+}
+
+struct LinkWebView: UIViewRepresentable {
+
+    var externalURL: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        guard let url = URL(string: externalURL) else {
+            return WKWebView()
+        }
+
+        let webView = WKWebView()
+        webView.load(URLRequest(url: url))
+
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+
+    }
+}
+
+#Preview {
+    LinkView(externalURL: "https://www.youtube.com/watch?v=kvRBrtrqjHc")
+}

--- a/TwoHoSun/Screens/Home/Vote/VoteContentView.swift
+++ b/TwoHoSun/Screens/Home/Vote/VoteContentView.swift
@@ -33,7 +33,8 @@ enum VoteType {
 
 struct VoteContentView: View {
     @State private var isVoteCompleted = false
-    @State var isImageDetailPresented = false
+    @State private var isImageDetailPresented = false
+    @State private var isLinkWebViewPresented = false
     @State var title: String
     @State var contents: String
     @State var imageURL: String
@@ -101,7 +102,12 @@ struct VoteContentView: View {
         }
         .fullScreenCover(isPresented: $isImageDetailPresented) {
             NavigationView {
-                ImageDetailView(image: $imageURL)
+                ImageDetailView(imageURL: imageURL, externalURL: externalURL)
+            }
+        }
+        .fullScreenCover(isPresented: $isLinkWebViewPresented) {
+            NavigationView {
+                LinkView(externalURL: externalURL)
             }
         }
     }
@@ -178,7 +184,7 @@ extension VoteContentView {
 
     private var linkButton: some View {
         Button {
-            print("linkButton did tap")
+            isLinkWebViewPresented = true
         } label: {
             HStack(spacing: 2) {
                 Image(systemName: "link")

--- a/TwoHoSun/TwoHoSunApp.swift
+++ b/TwoHoSun/TwoHoSunApp.swift
@@ -15,12 +15,12 @@ struct TwoHoSunApp: App {
     var body: some Scene {
         WindowGroup {
 //            if appState.hasValidToken {
-//                MainTabView()
+                MainTabView()
 //            } else {
 //              DetailView()
 //            }
 //
-            VoteCellView()
+//            VoteCellView()
         }
     }
 }

--- a/TwoHoSun/TwoHoSunApp.swift
+++ b/TwoHoSun/TwoHoSunApp.swift
@@ -20,7 +20,6 @@ struct TwoHoSunApp: App {
 //              DetailView()
 //            }
 //
-//            VoteCellView()
         }
     }
 }


### PR DESCRIPTION
## 🔥 Pull requests

🍃 작업한 브랜치
- feature/#42

## ✏️ 작업한 내용 
알림뷰 레이아웃 제작

## 📌 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 원래 화면 전환이 되었을 때, tabView를 숨기기 위해서 `MainTabView`에 있는 tabView 자체를 navigationView(Stack)으로 감싸주면 되는데, 이 방식으로 했을 때 `MainView`에서 navigation bar 오류가 생깁니다
더이상 방법이 생각나지 않스민다... 도와주십시오 ! .. ㅜ
## 📷 스크린샷
<!-- 작업한 뷰의 스크린샷을 올려주세요. -->
<!-- 이미지 크기를 30%로 줄여서 올려주세요. ex. <img src = "이미지 주소" width = 30%>-->

<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team8-2HoSun/assets/108191001/7489bf53-9bcb-48b7-85e3-e898fcb1bc65" width = 30%>

## 📮 관련 이슈
- Resolved: #42 
