### PR TITLE
소비고민 탭 레이아웃 제작

### DIFF
--- a/TwoHoSun/Screens/Common/WoteTabView.swift
+++ b/TwoHoSun/Screens/Common/WoteTabView.swift
@@ -50,7 +50,7 @@ enum VoteCategoryType {
     var title: String {
         switch self {
         case .all:
-            return "전국투표"
+            return "전국 투표"
         case .mySchool:
             return "OO고등학교 투표"
         }
@@ -74,25 +74,11 @@ struct WoteTabView: View {
                         }
                 }
             }
-            .tint(Color.accentBlue)
             .onAppear {
                 UITabBar.appearance().unselectedItemTintColor = .gray100
                 UITabBar.appearance().backgroundColor = .background
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    voteCategoryButton
-                }
-
-                ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: 0) {
-                        notificationButton
-                        searchButton
-                    }
-                }
-            }
-            .toolbarBackground(Color.background, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
+            .tint(Color.accentBlue)
         }
     }
 }
@@ -149,7 +135,6 @@ extension WoteTabView {
                             .padding(.bottom, 14)
                     }
                 }
-                .frame(width: 131, height: 88)
                 .font(.system(size: 14))
                 .foregroundStyle(Color.woteWhite)
                 .background(
@@ -158,37 +143,6 @@ extension WoteTabView {
                         .strokeBorder(Color.gray300, lineWidth: 1)
                 )
                 .offset(y: 70)
-            }
-        }
-        .zIndex(1)
-    }
-
-    private var notificationButton: some View {
-        NavigationLink {
-            NotificationView()
-        } label: {
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .frame(width: 39, height: 39)
-                    .foregroundStyle(Color.disableGray)
-                Image(systemName: "bell.fill")
-                    .font(.system(size: 16))
-                    .foregroundStyle(Color.woteWhite)
-            }
-        }
-    }
-
-    private var searchButton: some View {
-        NavigationLink {
-            SearchView()
-        } label: {
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .frame(width: 39, height: 39)
-                    .foregroundStyle(Color.disableGray)
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 16))
-                    .foregroundStyle(Color.woteWhite)
             }
         }
     }

--- a/TwoHoSun/Screens/Common/WoteTabView.swift
+++ b/TwoHoSun/Screens/Common/WoteTabView.swift
@@ -74,12 +74,15 @@ struct WoteTabView: View {
                         }
                 }
             }
+            .tint(Color.accentBlue)
             .onAppear {
                 UITabBar.appearance().unselectedItemTintColor = .gray100
                 UITabBar.appearance().backgroundColor = .background
             }
-            .tint(Color.accentBlue)
+            .navigationTitle(selection.tabTitle)
+            .toolbar(.hidden, for: .navigationBar)
         }
+        .tint(Color.accentBlue)
     }
 }
 

--- a/TwoHoSun/Screens/Home/Main/MainVoteView.swift
+++ b/TwoHoSun/Screens/Home/Main/MainVoteView.swift
@@ -32,13 +32,25 @@ enum UserVoteType {
 struct MainVoteView: View {
     @State private var isVoted = false
     @State private var selectedVoteType = UserVoteType.agree
+    @State private var selectedVoteCategoryType = VoteCategoryType.all
+    @State private var isVoteCategoryButtonDidTap = false
     let viewModel: MainVoteViewModel
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
             Color.background
                 .ignoresSafeArea()
-            votePagingView
+            ZStack(alignment: .topLeading) {
+                VStack(spacing: 0) {
+                    navigationBar
+                    votePagingView
+                }
+
+                if isVoteCategoryButtonDidTap {
+                    voteCategoryMenu
+                        .offset(x: 16, y: 40)
+                }
+            }
             createVoteButton
                 .padding(.bottom, 21)
                 .padding(.trailing, 24)
@@ -49,10 +61,97 @@ struct MainVoteView: View {
 
 extension MainVoteView {
 
-    private var voteCategory: some View {
-        Text("고등학교 투표")
-            .font(.system(size: 20, weight: .bold))
-            .foregroundStyle(.white)
+    private var navigationBar: some View {
+        HStack(spacing: 0) {
+            voteCategoryButton
+            Spacer()
+            notificationButton
+                .padding(.trailing, 8)
+            searchButton
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private var notificationButton: some View {
+        NavigationLink {
+            NotificationView()
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .frame(width: 39, height: 39)
+                    .foregroundStyle(Color.disableGray)
+                Image(systemName: "bell.fill")
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.woteWhite)
+            }
+        }
+    }
+
+    private var searchButton: some View {
+        NavigationLink {
+            SearchView()
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .frame(width: 39, height: 39)
+                    .foregroundStyle(Color.disableGray)
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.woteWhite)
+            }
+        }
+    }
+
+    private var voteCategoryMenu: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                selectedVoteCategoryType = .all
+                isVoteCategoryButtonDidTap = false
+                // TODO: - fetch new data
+            } label: {
+                Text("전국 투표")
+                    .padding(.leading, 15)
+                    .padding(.top, 14)
+                    .padding(.bottom, 12)
+            }
+            Divider()
+                .background(Color.gray300)
+            Button {
+                selectedVoteCategoryType = .mySchool
+                isVoteCategoryButtonDidTap = false
+                // TODO: - fetch new data
+            } label: {
+                Text("우리 학교 투표")
+                    .padding(.leading, 15)
+                    .padding(.top, 12)
+                    .padding(.bottom, 14)
+            }
+        }
+        .frame(width: 131, height: 88)
+        .font(.system(size: 14))
+        .foregroundStyle(Color.woteWhite)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.disableGray)
+                .strokeBorder(Color.gray300, lineWidth: 1)
+        )
+    }
+
+    private var voteCategoryButton: some View {
+        ZStack(alignment: .topLeading) {
+            Button {
+                isVoteCategoryButtonDidTap.toggle()
+            } label: {
+                HStack(spacing: 5) {
+                    Text(selectedVoteCategoryType.title)
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(.white)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 16))
+                        .foregroundStyle(Color.descriptionGray)
+                }
+            }
+        }
     }
 
     private var votePagingView: some View {
@@ -160,6 +259,7 @@ extension MainVoteView {
         return Int((voteRatio * 10).truncatingRemainder(dividingBy: 10))
     }
 }
+
 
 #Preview {
     WoteTabView()

--- a/TwoHoSun/Screens/Home/Main/MainVoteView.swift
+++ b/TwoHoSun/Screens/Home/Main/MainVoteView.swift
@@ -34,6 +34,7 @@ struct MainVoteView: View {
     @State private var selectedVoteType = UserVoteType.agree
     @State private var selectedVoteCategoryType = VoteCategoryType.all
     @State private var isVoteCategoryButtonDidTap = false
+    @State private var currentVote = 0
     let viewModel: MainVoteViewModel
 
     var body: some View {
@@ -156,9 +157,11 @@ extension MainVoteView {
 
     private var votePagingView: some View {
         GeometryReader { proxy in
-            TabView {
-                ForEach(0..<5) { _ in
+            TabView(selection: $currentVote) {
+                // TODO: - cell 5개로 설정해 둠
+                ForEach(0..<5) { index in
                     voteContentCell
+                        .tag(index)
                 }
                 .rotationEffect(.degrees(-90))
                 .frame(width: proxy.size.width, height: proxy.size.height)
@@ -225,15 +228,20 @@ extension MainVoteView {
         }
     }
 
+    @ViewBuilder
     private var nextVoteButton: some View {
-        HStack {
-            Spacer()
-            Button {
-                print("swipe gesture")
-            } label: {
-                Image("icnCaretDown")
+        if currentVote != 4 {
+            HStack {
+                Spacer()
+                Button {
+                    withAnimation {
+                        currentVote += 1
+                    }
+                } label: {
+                    Image("icnCaretDown")
+                }
+                Spacer()
             }
-            Spacer()
         }
     }
 
@@ -259,7 +267,6 @@ extension MainVoteView {
         return Int((voteRatio * 10).truncatingRemainder(dividingBy: 10))
     }
 }
-
 
 #Preview {
     WoteTabView()

--- a/TwoHoSun/Screens/Home/Main/MainVoteView.swift
+++ b/TwoHoSun/Screens/Home/Main/MainVoteView.swift
@@ -56,6 +56,9 @@ struct MainVoteView: View {
                 .padding(.bottom, 21)
                 .padding(.trailing, 24)
         }
+        .onTapGesture {
+            isVoteCategoryButtonDidTap = false
+        }
     }
 
 }

--- a/TwoHoSun/Screens/Home/Search/SearchView.swift
+++ b/TwoHoSun/Screens/Home/Search/SearchView.swift
@@ -32,8 +32,7 @@ struct SearchView: View {
             .padding(.horizontal, 16)
             .padding(.top, 20)
         }
-        .toolbarBackground(Color.background, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text("통합검색")


### PR DESCRIPTION
## 🔥 Pull requests

🍃 작업한 브랜치
- feature/#93

## ✏️ 작업한 내용 
- 버튼 눌렀을 때 swipe되도록
- 전국투표/우리학교 투표 버튼 추가
- 다른 곳 눌렀을 때 전국투표/우리학교 버튼 닫히도록 추가 

## 📌 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 셀은 5개까지만 나오도록 하드코딩해 두었습니당

## 📷 스크린샷
<!-- 작업한 뷰의 스크린샷을 올려주세요. -->
<!-- 이미지 크기를 30%로 줄여서 올려주세요. ex. <img src = "이미지 주소" width = 30%>-->

<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team8-2HoSun/assets/108191001/d8e6ea27-324d-48c0-b30f-bc79a2c2912a" width = 30%>


## 📮 관련 이슈
- Resolved: #93 
