### PR TITLE
회원탈퇴 후 회원가입 시 기존 프로필 데이터가 남아있는 버그 수정

### DIFF
--- a/TwoHoSun/Screens/MyPage/Setting/SettingViewModel.swift
+++ b/TwoHoSun/Screens/MyPage/Setting/SettingViewModel.swift
@@ -51,6 +51,7 @@ class SettingViewModel {
             } receiveValue: { _ in
                 self.loginStateManager.serviceRoot.auth.deleteTokens()
                 self.loginStateManager.serviceRoot.auth.authState = .none
+                self.loginStateManager.serviceRoot.memberManager.profile = nil
             }
             .store(in: &cancellable)
     }


### PR DESCRIPTION
## 🔥 Pull requests

🍃 작업한 브랜치
- feature/#190

## ✏️ 작업한 내용 
회원탈퇴 후 회원가입 시 기존 프로필 데이터가 남아있는 버그 수정
- [x] 회원탈퇴 시 기존 프로필 데이터 삭제

## 📌 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📷 스크린샷
<!-- 작업한 뷰의 스크린샷을 올려주세요. -->
<!-- 이미지 크기를 30%로 줄여서 올려주세요. ex. <img src = "이미지 주소" width = 30%>-->

## 📮 관련 이슈
- Resolved: #190 
